### PR TITLE
API incompatibility with sabredav 2.1.3 fixed

### DIFF
--- a/lib/SabreZarafa/PrincipalsBackend.php
+++ b/lib/SabreZarafa/PrincipalsBackend.php
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Project page: <http://github.com/1afa/sabre-zarafa/>
+ * Project page: <http://github.com/bokxing-it/sabre-zarafa/>
  * 
  */
 
@@ -206,7 +206,7 @@ class PrincipalsBackend implements \Sabre\DAVACL\PrincipalBackend\BackendInterfa
 	 * @return string
 	 */
 	public function
-	findByUri ($uri)
+	findByUri ($uri, $principalPrefix)
 	{
 		$this->logger->trace(__FUNCTION__."($uri)");
 


### PR DESCRIPTION
This bug is causing trouble using any versions below v0.23 that makes use of sabredav ~2.0.0 dependency.

Here are some posts about that:
https://forums.zarafa.com/showthread.php?6904-SabreDAV-backend-for-Zarafa/page21

I'm creating this package from the related github tag on archlinux. php-composer always downloads the latest 2.x, so the wrong interface will make php fail running it.

https://aur.archlinux.org/packages/sabre-zarafa/

Could you please consider to create a v0.23.1 tag/release?


Thanks! MartiMcFly
