### PR TITLE
Compatibility with Kopano

### DIFF
--- a/lib/SabreZarafa/PrincipalsBackend.php
+++ b/lib/SabreZarafa/PrincipalsBackend.php
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Project page: <http://github.com/bokxing-it/sabre-zarafa/>
+ * Project page: <http://github.com/1afa/sabre-zarafa/>
  * 
  */
 

--- a/lib/SabreZarafa/PrincipalsBackend.php
+++ b/lib/SabreZarafa/PrincipalsBackend.php
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Project page: <http://github.com/1afa/sabre-zarafa/>
+ * Project page: <http://github.com/bokxing-it/sabre-zarafa/>
  * 
  */
 
@@ -206,7 +206,7 @@ class PrincipalsBackend implements \Sabre\DAVACL\PrincipalBackend\BackendInterfa
 	 * @return string
 	 */
 	public function
-	findByUri ($uri)
+	findByUri ($uri, $principalPrefix)
 	{
 		$this->logger->trace(__FUNCTION__."($uri)");
 

--- a/server.php
+++ b/server.php
@@ -36,7 +36,7 @@ include __DIR__ . '/version.inc.php';
 include __DIR__ . '/config.inc.php';
 
 // Expand the include path with the standard location for the PHP-MAPI includes:
-set_include_path(get_include_path() . PATH_SEPARATOR . '/usr/share/php/');
+set_include_path(get_include_path() . PATH_SEPARATOR . '/usr/share/kopano/php/');
 
 // Include PHP-MAPI libraries:
 include 'mapi/mapi.util.php';
@@ -57,7 +57,8 @@ $logger->trace(sprintf('Initializing Sabre-Zarafa version %s, revision %s', SABR
 
 // Disable MAPI exceptions;
 // we handle errors by checking a function's return status (at least for now):
-mapi_enable_exceptions(false);
+// Makes MAPI.SO CRASH
+// mapi_enable_exceptions(false);
 
 function checkMapiError($msg) {
 	global $logger;


### PR DESCRIPTION
Make compatible with Kopano and try avoiding mapi.so crash...

Jan 17 17:36:05 alarm systemd[1]: Started Process Core Dump (PID 11343/UID 0).
Jan 17 17:36:05 alarm nginx[3939]: 2018/01/17 17:36:05 [error] 3941#3941: *324 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 192.168.178.25, server: , request: "GET /carddav HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm/kopano-sabre.sock:", host: "192.168.178.45"
Jan 17 17:36:05 alarm php-fpm[16761]: [WARNING] [pool kopano-sabre] child 11342 exited on signal 11 (SIGSEGV - core dumped) after 0.263330 seconds from start
Jan 17 17:36:05 alarm php-fpm[16761]: [NOTICE] [pool kopano-sabre] child 11345 started
Jan 17 17:36:06 alarm systemd-coredump[11344]: Process 11342 (php-fpm) of user 33 dumped core.

                                               Stack trace of thread 11342:
                                               #0  0x00000000b402d434 n/a (mapi.so)
